### PR TITLE
bluebird is needed in prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,8 @@
     "/lib/",
     "/src/"
   ],
-  "peerDependencies": {
-    "bluebird": "^3.5.1"
-  },
   "dependencies": {
+    "bluebird": "^3.5.1",
     "lodash": "^4.17.5"
   },
   "devDependencies": {
@@ -22,7 +20,6 @@
     "babel-preset-firecloud": "git://github.com/tobiipro/babel-preset-firecloud.git#semver:~0.1.4",
     "babel-register": "^6.26.0",
     "babel-runtime": "^6.26.0",
-    "bluebird": "^3.5.1",
     "eclint": "^2.6.0",
     "eslint": "^4.18.2",
     "eslint-config-firecloud": "git://github.com/tobiipro/eslint-config-firecloud.git#semver:~0.2.2",


### PR DESCRIPTION
Fixes #4 

once the babel target moves to nodejs 8.x.x (where async/await syntax is available),
bluebird can be removed altogether