### PR TITLE
load mixins inside preval, or else tools like webpack need hints to b…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,7 @@
 import __ from 'lodash';
 import _mixins from './mixins';
 
-export let mixins = __.reduce(_mixins, function(mixins, mixinModule) {
-  mixinModule = `./mixins/${mixinModule}`;
-
-  // eslint-disable-next-line global-require
-  mixinModule = require(mixinModule);
-
-  mixins = __.merge(mixins, __.omit(mixinModule, [
-    'default'
-  ]));
-
-  return mixins;
-}, {});
+export let mixins = _mixins;
 
 // eslint-disable-next-line firecloud/no-underscore-prefix-exported
 export let _ = (function() {

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -3,6 +3,10 @@
 // Have a look at `src/index.js` for how this module's exports are used.
 
 // @preval
+
+// eslint-disable-next-line import/no-unassigned-import
+require('@babel/register');
+
 let _ = require('lodash');
 let fs = require('fs');
 let path = require('path');
@@ -21,6 +25,13 @@ module.exports = _.reduce(mixinModules, function(acc, mixinModule) {
     return acc;
   }
 
-  acc.push(mixinModule);
+  // eslint-disable-next-line global-require
+  mixinModule = require(`./${mixinModule}`);
+
+  let mixins = _.omit(mixinModule, [
+    'default'
+  ]);
+
+  acc = _.merge(acc, mixins);
   return acc;
-}, []);
+}, {});


### PR DESCRIPTION
…undle the mixin modules

<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [ ]

---

<!-- Describe your contribution -->

this is one way to solve it (I tested manually)

another way would be to use magic comments like `webpackInclude`,
or to make sure to use a template literal in the require calls e.g. `require(module)` would not work, but `require(\`../some/path/${someModule}\`)` would actually make webpack bundle all the files under `../some/path/`

both of the alternatives felt flimsy and webpack specific