### PR TITLE
Upgrade lodash to a version patched for prototype pollution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/lodash": "4.14.160",
     "@types/resize-observer-browser": "^0.1.2",
     "hard-rejection": "^2.1.0",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.20",
     "outdent": "^0.7.0",
     "utility-types": "^3.10.0"
   },


### PR DESCRIPTION
* Fixes:
* Breaking change: [ ]

---

A bunch of our repos depending on lodash-firecloud has a security warning currently due to an unpatched version of lodash. Since we do use lodash in our apps it should be worth upgrading to a fixed version 

https://github.com/advisories/GHSA-p6mc-m468-83gw
